### PR TITLE
change separator in GridDetails' names to :

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,8 @@ CHANGES IN VERSION 1.5.6
 ------------------------
  o change the default value of grid.ppm.from to 2
    (was 5 before) [2014-03-05 Wed]
+ o change the separator in GridDetails' names to ":"
+   (was "." before) [2014-03-07 Fri]
  o 
 
 CHANGES IN VERSION 1.5.5

--- a/R/utils.R
+++ b/R/utils.R
@@ -426,7 +426,7 @@ gridSearch2 <- function(model,
   }
   nms <- paste(rep(nsds, each = m) ,
                rep(ppms, n),
-               sep=".")
+               sep=":")
   names(details) <- nms
   return(list(prcntTotal = grd1,
               prcntModel = grd2,


### PR DESCRIPTION
Dear Laurent,

as discussed a few hours ago this PR changes the separator in the names of the GridDetails list to `:` to improve readability by humans and machine.

``` s
# old style (nsd.ppm)
"4.5.20"
# new style (nsd:ppm)
"4.5:20"
```

This change should be safe because AFAIK the names are not used yet (only for printing in the report).

Best wishes,

Sebastian
